### PR TITLE
fix: change email sender to reply-to for ticket notifications

### DIFF
--- a/app/Notifications/TicketClosed.php
+++ b/app/Notifications/TicketClosed.php
@@ -37,7 +37,7 @@ class TicketClosed extends Notification
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->from($this->ticket->getSupportEmailWithTicketId())
+            ->replyTo($this->ticket->getSupportEmailWithTicketId())
             ->subject(__('Ticket closed'))
             ->line(__('We noticed that there was no response regarding your ticket, so it has been automatically closed.'))
             ->line(__('If you still need help, feel free to open a new ticket about this issue.'));

--- a/app/Notifications/TicketCommentByAgent.php
+++ b/app/Notifications/TicketCommentByAgent.php
@@ -37,7 +37,7 @@ class TicketCommentByAgent extends Notification
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->from($this->ticketComment->ticket->getSupportEmailWithTicketId())
+            ->replyTo($this->ticketComment->ticket->getSupportEmailWithTicketId())
             ->subject(__('New response to your ticket'))
             ->markdown(
                 'mail.ticket.comment', ['ticketComment' => $this->ticketComment]

--- a/app/Notifications/TicketCreated.php
+++ b/app/Notifications/TicketCreated.php
@@ -37,7 +37,7 @@ class TicketCreated extends Notification
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->from($this->ticket->getSupportEmailWithTicketId())
+            ->replyTo($this->ticket->getSupportEmailWithTicketId())
             ->subject(__("We've received your message"))
             ->line(__('Thank you for reaching out!'))
             ->line(__('We\'ve received your message and are reviewing it as quickly as possible.'))

--- a/app/Notifications/TicketEscalationRequired.php
+++ b/app/Notifications/TicketEscalationRequired.php
@@ -37,7 +37,7 @@ class TicketEscalationRequired extends Notification
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->from($this->ticket->getSupportEmailWithTicketId())
+            ->replyTo($this->ticket->getSupportEmailWithTicketId())
             ->subject(__('We need some information from you'))
             ->line(__('We need a few things to move forward:'))
             ->line(__('1. Ask your Account Manager to escalate the case (#:ticket_id) if they have not already.', ['ticket_id' => $this->ticket->ticket_id]))

--- a/app/Notifications/TicketResolved.php
+++ b/app/Notifications/TicketResolved.php
@@ -37,7 +37,7 @@ class TicketResolved extends Notification
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->from($this->ticket->getSupportEmailWithTicketId())
+            ->replyTo($this->ticket->getSupportEmailWithTicketId())
             ->subject(__('Ticket resolved'))
             ->line(__('An agent has marked your ticket as resolved.'))
             ->line(__('To reopen the ticket, simply reply to this email. Otherwise, it will be automatically closed after 48 hours.'));


### PR DESCRIPTION
This PR implements a hotfix to use the support email with ticket ID as the reply-to address instead of the from sender. This ensures that replies go directly to the correct support address, while maintaining proper authentication and deliverability.
