### PR TITLE
fix: nullable on section_id with hc_forms

### DIFF
--- a/database/migrations/2025_04_14_111723_add_section_id_to_hc_forms_table.php
+++ b/database/migrations/2025_04_14_111723_add_section_id_to_hc_forms_table.php
@@ -13,6 +13,7 @@ return new class extends Migration
     {
         Schema::table('hc_forms', function (Blueprint $table) {
             $table->foreignUlid('section_id')
+                ->nullable()
                 ->after('user_id')
                 ->constrained('hc_sections')
                 ->cascadeOnDelete();


### PR DESCRIPTION
This PR fixes a migration. If you have existing forms, it throws an error

```  
SQLSTATE[23000]: Integrity constraint violation: 1452 Cannot add or update a child row: a foreign key constraint fails (`xxxxxx`.`#sql-7b508_1cf29`, CONSTRAINT `hc_forms_section_id_foreign` FOREIGN KEY (`section_id`) REFERENCES `hc_sections` (`id`) ON DELETE CASCADE) (Connection: mysql, SQL: alter table `hc_forms` add constraint `hc_forms_section_id_foreign` foreign key (`section_id`) references `hc_sections` (`id`) on delete cascade)
```